### PR TITLE
Fix error: Division by zero in c_factor

### DIFF
--- a/iso_forest.py
+++ b/iso_forest.py
@@ -128,7 +128,7 @@ class PathFactor(object):
 
     def find_path(self,T):
         if T.ntype == 'exNode':
-            if T.size == 1: return self.e
+            if T.size <= 1: return self.e
             else:
                 self.e = self.e + c_factor(T.size)
                 return self.e


### PR DESCRIPTION
Hello! We were working with some experimental data and found out that in some cases the algorithm would throw an error because we were dividing by zero in the function `c_factor`. We narrowed down the bug and found that it was because some nodes of type 'exNode' are of size zero (these are generated in the method `make_tree` - lines 89-93). A simply change from the equality check to the minor or equal check fixed that for us. 